### PR TITLE
Make the component matching regex less permissive to fix moz-button matches

### DIFF
--- a/src/arewefluentyet/recomp_components.py
+++ b/src/arewefluentyet/recomp_components.py
@@ -38,10 +38,10 @@ class RecompComponents(Milestone):
             self.mozilla_source = self.mozilla_source + "/"
         for component in component_names:
             mozilla_central_dir = os.path.abspath(self.mozilla_source)
-            query = f'document\.createElement\(\"{component}\"\)|<{component}|<html:{component}|is=\"{component}\"|is: \"{component}\"'
+            query = f'document\\.createElement\\(\"{component}\"\\)|<{component}(?!-)|<html:{component}(?!-)|is=\"{component}\"|is: \"{component}\"'
             print("Searching for:", query)
   
-            command = ['rg', query, mozilla_central_dir, "--count"]
+            command = ['rg', query, mozilla_central_dir, "--count", "--pcre2"]
             output = subprocess.run(command, capture_output=True, encoding="ascii")
             print(output.stdout, output.stderr)
 


### PR DESCRIPTION
This should make it so that we match `<moz-button` but not `<moz-button-group>` when {component} is replaced by "moz-button". Had to enable the pcre2 flag to make this regex work with ripgrep. The results look closer to me, but it'll be easier to verify once we're also filtering out tests, stories, etc.