### PR TITLE
RECOMP-427: Filter bundled files and storybook directory

### DIFF
--- a/recomp-ignore
+++ b/recomp-ignore
@@ -6,3 +6,5 @@
 *.rej
 tests/
 test/
+storybook/
+.bundle*


### PR DESCRIPTION
Since we were already ignoring story files, might as well ignore the entire storybook directory. There's a chance of the bundle files within the static-storybook directory will get searched, so this patch prevents that. Additionally we ignore any kind of .bundle file to be 100% sure we're not adding incorrect counts to our metrics.