### PR TITLE
RECOMP-428: Ignore component name in filename

### DIFF
--- a/src/arewefluentyet/recomp_components.py
+++ b/src/arewefluentyet/recomp_components.py
@@ -48,7 +48,7 @@ class RecompComponents(Milestone):
   
             # First, find all instances of the component, then get rid of
             # matches that have a comment in them
-            command = ['rg', query, browser, toolkit, '--pcre2', "--ignore-file", ignore_file]
+            command = ['rg', query, browser, toolkit, '--pcre2', "--ignore-file", ignore_file, "--iglob", f"!{component}.*"]
             comment_command = ['rg', comment_query, '-v', '--pcre2']
             initial_rg = subprocess.Popen((command), stdout=subprocess.PIPE)
             output = subprocess.run((comment_command), capture_output=True, encoding="ascii", stdin=initial_rg.stdout)


### PR DESCRIPTION
We don't want to count instances of components in the files where they are declared. For example, named-deck and named-deck.js