### PR TITLE
RECOMP-407: Set up action to pull new component usage data daily

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,13 +9,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install ripgrep
       - name: Checkout main branch
         uses: actions/checkout@v3
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
-        with:
-          ref: gh-pages
-          path: gh-pages
+      # - name: Checkout gh-pages branch
+      #   uses: actions/checkout@v3
+      #   with:
+      #     ref: gh-pages
+      #     path: gh-pages
       - name: Checkout mozilla/gecko-dev
         uses: actions/checkout@v3
         with:
@@ -31,7 +35,7 @@ jobs:
         run: >
           python src/arewefluentyet/aggregate.py
           --mc ./gecko-dev --git --gh-pages-data gh-pages/data
-          -m M3 --use-current-revision
+          -m RC --use-current-revision --pcre2
       - name: Update gh-pages branch
         run: |
           git config user.name github-actions

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Install ripgrep
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          . "$HOME/.cargo/env" 
-          cargo install ripgrep
+          curl -L0 https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep_14.1.0-1_amd64.deb --output ripgrep_14.1.0-1_amd64.deb
+          sudo dpkg -i ripgrep_14.1.0-1_amd64.deb
           rg -V
+          rg --pcre2-version
       - name: Checkout main branch
         uses: actions/checkout@v3
       - name: Checkout gh-pages branch
@@ -34,9 +34,10 @@ jobs:
       - run: pip install -r requirements.txt
 
       - name: Generate new data
-        run: |
-          rg -V
-          python src/arewefluentyet/aggregate.py --mc ./gecko-dev --git --gh-pages-data gh-pages/data -m RC --use-current-revision
+        run: >
+          python src/arewefluentyet/aggregate.py
+          --mc ./gecko-dev --git --gh-pages-data gh-pages/data
+          -m RC --use-current-revision
       - name: Update gh-pages branch
         run: |
           git config user.name github-actions

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,15 +11,16 @@ jobs:
     steps:
       - name: Install ripgrep
         run: |
-          sudo apt-get update
-          sudo apt-get install ripgrep
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . "$HOME/.cargo/env" 
+          cargo install ripgrep
       - name: Checkout main branch
         uses: actions/checkout@v3
-      # - name: Checkout gh-pages branch
-      #   uses: actions/checkout@v3
-      #   with:
-      #     ref: gh-pages
-      #     path: gh-pages
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: gh-pages
       - name: Checkout mozilla/gecko-dev
         uses: actions/checkout@v3
         with:
@@ -35,7 +36,7 @@ jobs:
         run: >
           python src/arewefluentyet/aggregate.py
           --mc ./gecko-dev --git --gh-pages-data gh-pages/data
-          -m RC --use-current-revision --pcre2
+          -m RC --use-current-revision
       - name: Update gh-pages branch
         run: |
           git config user.name github-actions

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -14,6 +14,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "$HOME/.cargo/env" 
           cargo install ripgrep
+          rg -V
       - name: Checkout main branch
         uses: actions/checkout@v3
       - name: Checkout gh-pages branch
@@ -33,10 +34,9 @@ jobs:
       - run: pip install -r requirements.txt
 
       - name: Generate new data
-        run: >
-          python src/arewefluentyet/aggregate.py
-          --mc ./gecko-dev --git --gh-pages-data gh-pages/data
-          -m RC --use-current-revision
+        run: |
+          rg -V
+          python src/arewefluentyet/aggregate.py --mc ./gecko-dev --git --gh-pages-data gh-pages/data -m RC --use-current-revision
       - name: Update gh-pages branch
         run: |
           git config user.name github-actions


### PR DESCRIPTION
We also ensure we have ripgrep v14.1.0 which supports `--pcre2`, since we absolutely need this for our ripgrep queries to work. I originally used `cargo` to install ripgrep, but since that builds from source, the action would take forever. That's why I went with just the compiled `.deb` and called it a day.