### PR TITLE
RECOMP-430, RECOMP-432 additional visual changes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,43 @@ const activeMilestone = new URL(document.location).searchParams.get(
   "milestone"
 );
 
+// Takes a color hex value and returns a grey tone.
+function generateGreyTone(color) {
+  // Remove '#' if present
+  let hex = color.replace("#", "");
+
+  // Parse hex into RGB
+  var r = parseInt(hex.substring(0, 2), 16);
+  var g = parseInt(hex.substring(2, 4), 16);
+  var b = parseInt(hex.substring(4, 6), 16);
+
+  // Calculate average
+  var avg = Math.round((r + g + b) / 3);
+
+  // Convert average to hex
+  var greyHex = avg.toString(16).padStart(2, "0");
+
+  // Return grey hex value
+  return "#" + greyHex + greyHex + greyHex;
+}
+
+let colors = [
+  "#F9CDAC",
+  "#F3ACA2",
+  "#EE8B97",
+  "#E96A8D",
+  "#DB5087",
+  "#B8428C",
+  "#973490",
+  "#742796",
+  "#5E1F88",
+  "#4D1A70",
+  "#3D1459",
+  "#2D0F41",
+];
+
+let greyTones = colors.map(generateGreyTone);
+
 const State = {
   milestones: [
     {
@@ -10,17 +47,17 @@ const State = {
       name: "mozilla-central",
       title: "Reusable Components usage",
       categories: [
-            "moz-button",
-            "moz-button-group",
-            "moz-card",
-            "moz-five-star",
-            "moz-label",
-            "moz-message-bar",
-            "moz-page-nav",
-            "moz-support-link",
-            "moz-toggle",
-            "named-deck",
-            "panel-list",
+        "moz-button",
+        "moz-button-group",
+        "moz-card",
+        "moz-five-star",
+        "moz-label",
+        "moz-message-bar",
+        "moz-page-nav",
+        "moz-support-link",
+        "moz-toggle",
+        "named-deck",
+        "panel-list",
       ],
       skipInDashboard: [],
       categoriesBar: [0, 10],
@@ -43,19 +80,8 @@ const State = {
       background: "white",
     },
     categories: {
-      colors: {
-        "moz-button": "red",
-        "moz-button-group": "pink",
-        "moz-card": "blue",
-        "moz-five-star": "yelow",
-        "moz-label": "orange",
-        "moz-message-bar": "green",
-        "moz-page-nav": "lightgreen",
-        "moz-support-link": "lightblue",
-        "moz-toggle": "grey",
-        "named-deck": "magenta",
-        "panel-list": "salmon",
-      },
+      colors,
+      greyTones,
       labels: {
         "moz-button": "moz-button",
         "moz-button-group": "moz-button-group",
@@ -332,12 +358,6 @@ const Page = {
     return sizeMode == "large"
       ? State.theme.datalabels.labels.font.size.large
       : State.theme.datalabels.labels.font.size.small;
-  },
-  shouldDisplayLegend(
-    aspectMode = State.aspectMode,
-    sizeMode = State.sizeMode
-  ) {
-    return sizeMode == "small";
   },
 };
 

--- a/js/chart.js
+++ b/js/chart.js
@@ -126,12 +126,35 @@ function get_chart(ctx, data, all_labels, month_labels) {
         },
       },
       legend: {
-        display: Page.shouldDisplayLegend(),
-        position: "bottom",
+        display: true,
+        reverse: true,
+        position: "left",
         labels: {
           filter: function (l) {
             return Page.getActiveMilestone().categories.includes(l.text);
           },
+        },
+        onClick: function (event, legendItem, legend) {
+          if (this.chart.filtered && this.chart.filteredBy == legendItem.text) {
+            this.chart.filtered = false;
+            this.chart.filteredBy = "";
+          } else {
+            this.chart.filtered = true;
+            this.chart.filteredBy = legendItem.text;
+          }
+
+          this.chart.data.datasets.forEach((dataset) => {
+            if (
+              this.chart.filtered &&
+              dataset.label !== this.chart.filteredBy
+            ) {
+              dataset.backgroundColor = dataset.greyBackgroundColor;
+            } else {
+              let index = Page.getCategories().indexOf(dataset.label);
+              dataset.backgroundColor = State.theme.categories.colors[index];
+            }
+          });
+          this.chart.update();
         },
       },
     },

--- a/js/index.js
+++ b/js/index.js
@@ -88,5 +88,16 @@ function create_chart(selector, { all_labels, month_labels, data }) {
   });
 
   let ctx = document.querySelector(selector).getContext("2d");
-  return get_chart(ctx, data, all_labels, month_labels);
+  let chart = get_chart(ctx, data, all_labels, month_labels);
+  document.addEventListener("click", (e) => {
+    if (e.target.localName !== "canvas" && chart.filtered) {
+      chart.data.datasets.forEach((dataset) => {
+        let index = Page.getCategories().indexOf(dataset.label);
+        dataset.backgroundColor = State.theme.categories.colors[index];
+      });
+      chart.filtered = false;
+      chart.update();
+    }
+  })
+  return chart;
 }

--- a/vendor/chartjs-plugin-datalabels.js
+++ b/vendor/chartjs-plugin-datalabels.js
@@ -538,7 +538,8 @@ function drawTextLine(ctx, text, cfg) {
 			  ctx.fillText(`\u2B24 ${value}`, x, y, w);
 			}
 			let category = isNaN(label) ? getCategoryForLabel(label) : Page.getCategories()[label];
-			let color = State.theme.categories.colors[category];
+			let index = Page.getCategories().indexOf(category);
+			let color = State.theme.categories.colors[index];
 			ctx.fillStyle = color;
 			ctx.fillText("\u2B24", x, y, w);
 			ctx.fillStyle = State.theme.main.font.color;


### PR DESCRIPTION
This patch adds a new colour palette, sorts the data, and introduces a legend that can be clicked to filter down to a specific dataset

Unfiltered:

<img width="1450" alt="Screenshot 2024-04-23 at 10 48 01 AM" src="https://github.com/FirefoxUX/recomp-metrics/assets/15138046/11b8d552-6deb-458d-8238-7c6bc522b243">

Filtered:
<img width="1467" alt="Screenshot 2024-04-23 at 10 48 17 AM" src="https://github.com/FirefoxUX/recomp-metrics/assets/15138046/43a24315-ab67-4def-8985-19e41beafb6e">
