### PR TITLE
Add total count and component count

### DIFF
--- a/js/data.mjs
+++ b/js/data.mjs
@@ -183,6 +183,7 @@ export async function prepare_data(url) {
               });
               result += "\n";
               let values = [];
+              let totalCount = 0;
               for (let category of categories) {
                 if (!categoriesWithData.has(category)) {
                   continue;
@@ -190,9 +191,18 @@ export async function prepare_data(url) {
                 let label = State.theme.categories.labels[category];
                 let value =
                   getDatasetByLabel(ctx.chart, label).data[index] || 0;
+                if (!value) {
+                  continue;
+                }
                 values.push(`! \u2B24 ${label}|${value}`);
+                totalCount += value;
               }
-              result += values.reverse().join("\n");
+              result += [
+                ...values.reverse(),
+                `Components: ${values.length}`,
+                `Total: ${totalCount}`
+              ].join("\n");
+
               return result;
             },
           };


### PR DESCRIPTION
This adds a total count and component count to the metrics display. It also only shows counts for components that exist to minimize the dialog being cut off at the left side of the graph:

<img width="1348" alt="Screenshot 2025-03-21 at 15 57 50" src="https://github.com/user-attachments/assets/9c965944-3674-4fff-addd-08ca03b9e27a" />
