### PR TITLE
Add logic to find moz- components dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ The aggregator for `RC` can be called like this:
 python3 src/recomp-metrics/aggregate.py -m RC --mc ../mozilla-unified --gh-pages-data gh-pages/data --use-current-revision
 ```
 
+If you're using git instead of mercurial you'll need to pass a `--git` flag to get the data generation working:
+
+```
+python3 src/recomp-metrics/aggregate.py -m RC --mc ../mozilla-unified --gh-pages-data gh-pages/data --use-current-revision --git
+```
+
 ## Committing the Data
 
 Once you've generated new data for `RC`, you may want to serve the static site locally to view the update yourself. For example, you can run `python3 -m http.server 8000` from the folder with the `gh-pages` clone.
@@ -78,3 +84,13 @@ Ultimately, you will need to add the changes as a commit on the `gh-pages` branc
 modified:   data/RC/progress.json
 modified:   data/RC/snapshot.json
 ```
+
+## Running Everything Locally
+
+We often make changes to the `main` and `gh-pages` branches simultaneously. To get all the pieces working together locally, follow these steps:
+
+1. From the `main` branch checkout whatever feature branch you are working on or reviewing
+2. Run the command to generate data
+3. `cd` into `gh-pages`
+4. Switch to the `gh-pages` branch you are working on or reviewing
+5. Run `python3 -m http.server 8000` to start a local server

--- a/src/recomp-metrics/recomp_components.py
+++ b/src/recomp-metrics/recomp_components.py
@@ -10,28 +10,13 @@ from milestone import Milestone
 
 from pathlib import Path
 
+
 class RecompComponents(Milestone):
     name = "RC"
     start_date = date(2022, 8, 1)
 
     def get_data(self, source: Source, date, revision):
-        component_names=[
-            "moz-button",
-            "moz-button-group",
-            "moz-card",
-            "moz-checkbox",
-            "moz-fieldset",
-            "moz-five-star",
-            "moz-label",
-            "moz-message-bar",
-            "moz-page-nav",
-            "moz-radio",
-            "moz-radio-group",
-            "moz-support-link",
-            "moz-toggle",
-            "named-deck",
-            "panel-list",
-        ]
+        component_names = []
         entries = {}
         progress = {}
         # Ensure the mozilla-central arg has the trailing directory separator
@@ -39,8 +24,26 @@ class RecompComponents(Milestone):
         # and Unix
         if self.mozilla_source[-1] != "/":
             self.mozilla_source = self.mozilla_source + "/"
+
+        mozilla_central_dir = os.path.abspath(self.mozilla_source)
+        toolkit_widgets_dir = os.path.join(
+            mozilla_central_dir, "toolkit/content/widgets/"
+        )
+        widget_contents = os.listdir(toolkit_widgets_dir)
+
+        # Iterate over the contents of the toolkit/contents/widgets dir and look
+        # for folders that start with moz-, with special casing for moz-radio
+        # (sub-component of moz-radio-group) and named-deck (not in a folder)
+        for item in widget_contents:
+            if os.path.isdir(os.path.join(toolkit_widgets_dir, item)):
+                if item.startswith("moz-radio"):
+                    component_names.extend([item, item.removesuffix("-group")])
+                elif item.startswith("moz-") or item == "panel-list":
+                    component_names.append(item)
+            elif "named-deck" in item:
+                    component_names.append(os.path.splitext(item)[0])
+
         for component in component_names:
-            mozilla_central_dir = os.path.abspath(self.mozilla_source)
             query = f'document\\.createElement\\(\"{component}\"\\)|<{component}(?!-)|<html:{component}(?!-)|is=\"{component}\"|is: \"{component}\"'
             comment_query = '(?:\*|\/\/)([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*'
             print("Searching for:", query)


### PR DESCRIPTION
This is really just the first half of the work as I've realized we also have the list of components hardcoded in a few places in the frontend JS code. I'll put up another patch once I get that sorted.

Update: front end changes are up at https://github.com/FirefoxUX/recomp-metrics/pull/25