### PR TITLE
Dynamically generate list of component names on the front end

### DIFF
--- a/js/app.mjs
+++ b/js/app.mjs
@@ -1,28 +1,10 @@
-export const COMPONENTS = [
-  "moz-button-group",
-  "moz-button",
-  "moz-card",
-  "moz-checkbox",
-  "moz-fieldset",
-  "moz-five-star",
-  "moz-label",
-  "moz-message-bar",
-  "moz-page-nav",
-  "moz-radio-group",
-  "moz-radio",
-  "moz-support-link",
-  "moz-toggle",
-  "named-deck",
-  "panel-list",
-];
-
 const isDashboard = new URL(document.location).searchParams.has("dashboard");
 const activeMilestone = new URL(document.location).searchParams.get(
   "milestone"
 );
 
 // Takes a color hex value and returns a grey tone.
-function generateGreyTone(color) {
+export function generateGreyTone(color) {
   // Remove '#' if present
   let hex = color.replace("#", "");
 
@@ -64,11 +46,11 @@ function interpolateColor(startColor, endColor, factor = 0.5) {
 }
 
 // Function to generate a sacle colors for each component.
-function generateColors({
-  startColor,
-  midColor,
-  endColor,
-  items = COMPONENTS,
+export function generateColors({
+  startColor = "#F9CDAC",
+  midColor = "#E96A8D",
+  endColor = "#742796",
+  items,
 }) {
   let colorCount = items.length;
   let midPoint = Math.ceil(colorCount / 2);
@@ -89,21 +71,13 @@ function generateColors({
   return colors;
 }
 
-let startColor = "#F9CDAC";
-let midColor = "#E96A8D";
-let endColor = "#742796";
-
-// Generate colors for the list of components.
-let colors = generateColors({ startColor, midColor, endColor });
-let greyTones = colors.map(generateGreyTone);
-
 export const State = {
   milestones: [
     {
       code: "RC",
       name: "mozilla-central",
       title: "Reusable Components usage",
-      categories: COMPONENTS,
+      categories: [],
       skipInDashboard: [],
       categoriesBar: [0, 10],
       monthIntervals: 6,
@@ -125,12 +99,9 @@ export const State = {
       background: "white",
     },
     categories: {
-      colors,
-      greyTones,
-      labels: COMPONENTS.reduce(
-        (acc, componentName) => ({ ...acc, [componentName]: componentName }),
-        {}
-      ),
+      colors: [],
+      greyTones: [],
+      labels: [],
     },
     axes: {
       font: {

--- a/js/app.mjs
+++ b/js/app.mjs
@@ -4,7 +4,7 @@ const activeMilestone = new URL(document.location).searchParams.get(
 );
 
 // Takes a color hex value and returns a grey tone.
-export function generateGreyTone(color) {
+function generateGreyTone(color) {
   // Remove '#' if present
   let hex = color.replace("#", "");
 
@@ -46,7 +46,7 @@ function interpolateColor(startColor, endColor, factor = 0.5) {
 }
 
 // Function to generate a sacle colors for each component.
-export function generateColors({
+function generateColors({
   startColor = "#F9CDAC",
   midColor = "#E96A8D",
   endColor = "#742796",
@@ -171,6 +171,16 @@ export const State = {
     },
   },
   charts: [],
+  updateTheme(components) {
+    State.theme.categories.labels = components.reduce(
+      (acc, componentName) => ({ ...acc, [componentName]: componentName }),
+      {}
+    );
+    let colors = generateColors({ items: components });
+    let greyTones = colors.map(generateGreyTone);
+    State.theme.categories.colors = colors;
+    State.theme.categories.greyTones = greyTones;
+  },
 };
 window.State = State;
 

--- a/js/data.mjs
+++ b/js/data.mjs
@@ -1,5 +1,9 @@
-import { Page, State } from "./app.mjs";
-import { getBarCategories, getDatasetByLabel, getBarPosition } from "./helpers.mjs";
+import { Page, State, generateColors, generateGreyTone } from "./app.mjs";
+import {
+  getBarCategories,
+  getDatasetByLabel,
+  getBarPosition,
+} from "./helpers.mjs";
 
 export async function prepare_data(url) {
   let response = await fetch(url);
@@ -12,6 +16,16 @@ export async function prepare_data(url) {
     (a, b) => lastSnapshot[b] - lastSnapshot[a]
   );
   State.milestones[0].categories = sortedComponents;
+
+  // Dynamically set chart labels and colors based on components.
+  State.theme.categories.labels = sortedComponents.reduce(
+    (acc, componentName) => ({ ...acc, [componentName]: componentName }),
+    {}
+  );
+  let colors = generateColors({ items: sortedComponents });
+  let greyTones = colors.map(generateGreyTone);
+  State.theme.categories.colors = colors;
+  State.theme.categories.greyTones = greyTones;
 
   let all_labels = [];
   let all_points = {
@@ -200,7 +214,7 @@ export async function prepare_data(url) {
               result += [
                 ...values.reverse(),
                 `Components: ${values.length}`,
-                `Total: ${totalCount}`
+                `Total: ${totalCount}`,
               ].join("\n");
 
               return result;
@@ -244,7 +258,7 @@ export async function prepare_data(url) {
       });
     }
     let barCategories = getBarCategories();
-    Page.getCategories().forEach(function(category, index) {
+    Page.getCategories().forEach(function (category, index) {
       let inBar = barCategories.includes(category);
       datasets.push({
         type: "line",

--- a/js/data.mjs
+++ b/js/data.mjs
@@ -1,4 +1,4 @@
-import { Page, State, generateColors, generateGreyTone } from "./app.mjs";
+import { Page, State } from "./app.mjs";
 import {
   getBarCategories,
   getDatasetByLabel,
@@ -18,14 +18,7 @@ export async function prepare_data(url) {
   State.milestones[0].categories = sortedComponents;
 
   // Dynamically set chart labels and colors based on components.
-  State.theme.categories.labels = sortedComponents.reduce(
-    (acc, componentName) => ({ ...acc, [componentName]: componentName }),
-    {}
-  );
-  let colors = generateColors({ items: sortedComponents });
-  let greyTones = colors.map(generateGreyTone);
-  State.theme.categories.colors = colors;
-  State.theme.categories.greyTones = greyTones;
+  State.updateTheme(sortedComponents);
 
   let all_labels = [];
   let all_points = {

--- a/js/list.mjs
+++ b/js/list.mjs
@@ -1,5 +1,3 @@
-import { COMPONENTS } from "./app.mjs";
-
 const activeMilestone = new URL(document.location).searchParams.get(
   "milestone"
 );
@@ -10,7 +8,7 @@ const State = {
       code: "RC",
       name: "mozilla-central",
       title: "Reusable Components usage",
-      categories: COMPONENTS,
+      categories: [],
       columns: ["file", "count"],
       skipInDashboard: [],
       categoriesBar: [0, 10],
@@ -117,21 +115,23 @@ $(document).ready(async function () {
   let tableTemplate = document.getElementById("table-template");
   let tableContainer = document.getElementById("table-container");
 
-  data.forEach(({ component, data }, i) => {
-    let table = tableTemplate.cloneNode(true);
-    table.id = `data-table-${i}`;
-    tableContainer.appendChild(table);
+  data
+    .sort((a, b) => a.component.localeCompare(b.component))
+    .forEach(({ component, data }, i) => {
+      let table = tableTemplate.cloneNode(true);
+      table.id = `data-table-${i}`;
+      tableContainer.appendChild(table);
 
-    let tableHeading = document.createElement("h2");
-    tableHeading.innerText = `${component}`;
-    table.before(tableHeading);
-    $(table).DataTable({
-      data,
-      columns,
-      order,
-      destroy: true,
-      searching: false,
-      paging: false,
+      let tableHeading = document.createElement("h2");
+      tableHeading.innerText = `${component}`;
+      table.before(tableHeading);
+      $(table).DataTable({
+        data,
+        columns,
+        order,
+        destroy: true,
+        searching: false,
+        paging: false,
+      });
     });
-  });
 });


### PR DESCRIPTION
This patch goes hand in hand with the work done in https://github.com/FirefoxUX/recomp-metrics/pull/24 to dynamically generate the list of components on the backend. Since the data we get already includes the component names I figured we can generate our labels, colors, and table names on the front end based on that.